### PR TITLE
Server Liking API

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "typescript": "^4.6.3"
     },
     "dependencies": {
-        "@uoa-discords/shared-utils": "^2.1.7",
+        "@uoa-discords/shared-utils": "^2.2.7",
         "axios": "^0.26.1",
         "cors": "^2.8.5",
         "express": "^4.17.3",

--- a/src/classes/Caches.ts
+++ b/src/classes/Caches.ts
@@ -3,4 +3,6 @@ import CachedStorage from './template/CachedStored';
 
 export default abstract class Caches {
     public static readonly inviteCache = new CachedStorage<Invite>({ fileName: 'invites' });
+
+    public static readonly likesCache = new CachedStorage<string[]>({});
 }

--- a/src/classes/Caches.ts
+++ b/src/classes/Caches.ts
@@ -2,7 +2,9 @@ import { Invite } from '@uoa-discords/shared-utils';
 import CachedStorage from './template/CachedStored';
 
 export default abstract class Caches {
+    /** Invite objects indexed by guild ID. */
     public static readonly inviteCache = new CachedStorage<Invite>({ fileName: 'invites' });
 
+    /** Array of guild IDs a user has liked, indexed by user ID. */
     public static readonly likesCache = new CachedStorage<string[]>({});
 }

--- a/src/classes/template/CachedStored.ts
+++ b/src/classes/template/CachedStored.ts
@@ -1,24 +1,39 @@
+import { CombinedRoutes } from '@uoa-discords/shared-utils/dist/types';
+import ServerLogger from '../ServerLogger';
 import DataManager from './DataManager';
 
 export interface CachedStorageProps {
     /** Duration to store items, in seconds. Default is 5 minutes. */
     duration?: number;
 
-    /** Filename of data to read/write to, include if you want
-     * the cache to persist between reloads. */
+    /**
+     * Filename of data to read/write to.
+     *
+     * Include if you want the cache to persist between reloads. */
     fileName?: string;
+
+    /**
+     * Maximum number of key value pairs to store in the cache.
+     *
+     * Defaults to 100.
+     *
+     */
+    maxSize?: number;
 }
 
 /** Cached item storer, stores a record/dictionary of values in memory. */
 export default class CachedStorage<T> {
     private _items: Record<string, { data: T; timeout: NodeJS.Timeout }> = {};
 
+    private _currentSize = 0;
+    private readonly _maxSize: number = 100;
+
     /** Duration to store items, in seconds. */
-    private _duration: number;
+    private readonly _duration: number;
 
     private readonly _dataManager?: DataManager;
 
-    public constructor({ duration = 5 * 60, fileName }: CachedStorageProps) {
+    public constructor({ duration = 5 * 60, fileName, maxSize }: CachedStorageProps) {
         this._duration = duration;
         if (fileName) {
             this._dataManager = new DataManager(`data/caches/${fileName}.json`, JSON.stringify({}, undefined, 4));
@@ -27,7 +42,12 @@ export default class CachedStorage<T> {
 
             for (const key in storedDataValues) {
                 this.addItem(key, storedDataValues[key]);
+                this._currentSize++;
             }
+        }
+
+        if (maxSize) {
+            this._maxSize = maxSize;
         }
     }
 
@@ -35,6 +55,7 @@ export default class CachedStorage<T> {
     public clearAll(): void {
         Object.values(this._items).forEach(({ timeout }) => clearTimeout(timeout));
         this._items = {};
+        this._currentSize = 0;
         this.save();
     }
 
@@ -44,9 +65,21 @@ export default class CachedStorage<T> {
         }
     }
 
-    /** Adds an item to the cahce. */
+    /** Adds an item to the cache. */
     public addItem(key: string, value: T): void {
+        if (this._currentSize >= this._maxSize) {
+            ServerLogger.logError(
+                'CACHES' as CombinedRoutes,
+                `Hit max size (${this._currentSize}/${this._maxSize})`,
+                `Trying to add key: ${key}`,
+                'Value:',
+                value,
+            );
+            return;
+        }
+
         this.removeItem(key, true);
+        this._currentSize++;
         this._items[key] = {
             data: value,
             timeout: setTimeout(() => {
@@ -60,7 +93,7 @@ export default class CachedStorage<T> {
     /** Removes an item from the cache. */
     public removeItem(key: string, withoutSaving: boolean = false): void {
         if (!this._items[key]) return;
-
+        this._currentSize--;
         clearTimeout(this._items[key].timeout);
         delete this._items[key];
 

--- a/src/handlers/applications/acceptApplication.ts
+++ b/src/handlers/applications/acceptApplication.ts
@@ -65,6 +65,7 @@ async function acceptApplication(
             approvedAt: Date.now(),
             bot: applicationInQuestion.bot,
             memberCountHistory: [],
+            likes: 0,
         };
 
         await RegisteredServerModel.create(newServer);

--- a/src/handlers/servers/getServers.ts
+++ b/src/handlers/servers/getServers.ts
@@ -40,6 +40,7 @@ async function getServers(req: Request, res: Response): Promise<void> {
                     approvedAt: servers[i].approvedAt,
                     bot: servers[i].bot,
                     memberCountHistory: servers[i].memberCountHistory,
+                    likes: servers[i].likes ?? 0,
                 };
 
                 validServers.push(payload);

--- a/src/handlers/users/addLike.ts
+++ b/src/handlers/users/addLike.ts
@@ -51,7 +51,6 @@ async function addLike(req: Request<undefined, undefined, AddLikeRequest>, res: 
                 return;
             }
             user.guildsLiked.push(guildId);
-            res.sendStatus(200);
             await UserModel.findByIdAndUpdate(discordUser.data.id, user, { new: true });
         } else {
             // make new database user

--- a/src/handlers/users/addLike.ts
+++ b/src/handlers/users/addLike.ts
@@ -1,0 +1,73 @@
+import { AddLikeRequest, DiscordAPI, POSTUserRoutes, WebsiteUser } from '@uoa-discords/shared-utils';
+import { Request, Response } from 'express';
+import Caches from '../../classes/Caches';
+import ServerLogger from '../../classes/ServerLogger';
+import { RegisteredServerModel } from '../../models/RegisteredServerModel';
+import { UserModel } from '../../models/UserModel';
+
+async function getHasGuild(guildId: string): Promise<boolean> {
+    const fromInviteCache = Caches.inviteCache.getItem(guildId);
+    if (fromInviteCache) return true;
+
+    const fromDB = await RegisteredServerModel.findById(guildId);
+
+    return !!fromDB;
+}
+
+async function addLike(req: Request<undefined, undefined, AddLikeRequest>, res: Response): Promise<void> {
+    try {
+        const { access_token, guildId } = req.body;
+        if (typeof access_token !== 'string') {
+            res.status(400).json(`Body 'access_token must be a string (got ${typeof access_token})`);
+            return;
+        }
+
+        if (typeof guildId !== 'string') {
+            res.status(400).json(`Body 'guildId' must be a string (got ${typeof guildId})`);
+            return;
+        }
+
+        const [discordUser, validGuild] = await Promise.all([
+            DiscordAPI.getUserInfo(access_token),
+            getHasGuild(guildId),
+        ]);
+
+        if (!discordUser.success) {
+            res.status(401).json('Invalid access token');
+            return;
+        }
+
+        if (!validGuild) {
+            res.status(401).json('That guild is not registered');
+            return;
+        }
+
+        const user = await UserModel.findById(discordUser.data.id);
+
+        if (user) {
+            // modify existing database user
+            if (user.guildsLiked.includes(guildId)) {
+                res.status(400).json("You've already liked that guild");
+                return;
+            }
+            user.guildsLiked.push(guildId);
+            res.sendStatus(200);
+            await UserModel.findByIdAndUpdate(discordUser.data.id, user, { new: true });
+        } else {
+            // make new database user
+            const newUser: WebsiteUser = {
+                _id: discordUser.data.id,
+                guildsLiked: [guildId],
+            };
+            await UserModel.create(newUser);
+        }
+
+        Caches.likesCache.removeItem(discordUser.data.id);
+        res.sendStatus(200);
+    } catch (error) {
+        ServerLogger.logError(POSTUserRoutes.AddLike, error);
+        res.sendStatus(500);
+    }
+}
+
+export default addLike;

--- a/src/handlers/users/getLikes.ts
+++ b/src/handlers/users/getLikes.ts
@@ -1,0 +1,38 @@
+import { GETRoutes } from '@uoa-discords/shared-utils';
+import { Request, Response } from 'express';
+import Caches from '../../classes/Caches';
+import ServerLogger from '../../classes/ServerLogger';
+import { UserModel } from '../../models/UserModel';
+
+async function getCacheOrAddTo(id: string): Promise<string[]> {
+    const existing = Caches.likesCache.getItem(id);
+    if (existing) return existing;
+    const likesQuery = await UserModel.findById(id);
+
+    const data = likesQuery?.guildsLiked || [];
+
+    Caches.likesCache.addItem(id, data);
+
+    return data;
+}
+
+async function getLikes(req: Request, res: Response): Promise<void> {
+    try {
+        const { id } = req.params;
+
+        if (typeof id !== 'string') {
+            res.status(400).json(`User ID must be a string (got ${typeof id})`);
+            return;
+        }
+
+        const likes = await getCacheOrAddTo(id);
+
+        res.status(200).json(likes);
+        return;
+    } catch (error) {
+        ServerLogger.logError(GETRoutes.GetUserLikes, error);
+        res.sendStatus(500);
+    }
+}
+
+export default getLikes;

--- a/src/handlers/users/removeLike.ts
+++ b/src/handlers/users/removeLike.ts
@@ -1,10 +1,10 @@
-import { AddLikeRequest, DiscordAPI, POSTUserRoutes } from '@uoa-discords/shared-utils';
+import { DiscordAPI, POSTUserRoutes, RemoveLikeRequest } from '@uoa-discords/shared-utils';
 import { Request, Response } from 'express';
 import Caches from '../../classes/Caches';
 import ServerLogger from '../../classes/ServerLogger';
 import { UserModel } from '../../models/UserModel';
 
-async function removeLike(req: Request<undefined, undefined, AddLikeRequest>, res: Response): Promise<void> {
+async function removeLike(req: Request<undefined, undefined, RemoveLikeRequest>, res: Response): Promise<void> {
     try {
         const { access_token, guildId } = req.body;
         if (typeof access_token !== 'string') {

--- a/src/handlers/users/removeLike.ts
+++ b/src/handlers/users/removeLike.ts
@@ -1,0 +1,53 @@
+import { AddLikeRequest, DiscordAPI, POSTUserRoutes } from '@uoa-discords/shared-utils';
+import { Request, Response } from 'express';
+import Caches from '../../classes/Caches';
+import ServerLogger from '../../classes/ServerLogger';
+import { UserModel } from '../../models/UserModel';
+
+async function removeLike(req: Request<undefined, undefined, AddLikeRequest>, res: Response): Promise<void> {
+    try {
+        const { access_token, guildId } = req.body;
+        if (typeof access_token !== 'string') {
+            res.status(400).json(`Body 'access_token must be a string (got ${typeof access_token})`);
+            return;
+        }
+
+        if (typeof guildId !== 'string') {
+            res.status(400).json(`Body 'guildId' must be a string (got ${typeof guildId})`);
+            return;
+        }
+
+        const discordUser = await DiscordAPI.getUserInfo(access_token);
+
+        if (!discordUser.success) {
+            res.status(401).json('Invalid access token');
+            return;
+        }
+
+        const user = await UserModel.findById(discordUser.data.id);
+
+        if (!user) {
+            res.status(401).json("You don't have any likes registered");
+            return;
+        }
+
+        const index = user.guildsLiked.indexOf(guildId);
+
+        if (index === -1) {
+            res.status(401).json("You haven't liked that guild");
+            return;
+        }
+
+        user.guildsLiked.splice(index, 1);
+
+        await UserModel.findByIdAndUpdate(discordUser.data.id, user, { new: true });
+
+        Caches.likesCache.removeItem(discordUser.data.id);
+        res.sendStatus(200);
+    } catch (error) {
+        ServerLogger.logError(POSTUserRoutes.AddLike, error);
+        res.sendStatus(500);
+    }
+}
+
+export default removeLike;

--- a/src/models/RegisteredServerModel.ts
+++ b/src/models/RegisteredServerModel.ts
@@ -11,6 +11,7 @@ export const RegisteredServerSchema = new Schema<RegisteredServer>({
     approvedAt: Number,
     bot: {},
     memberCountHistory: [Number],
+    likes: Number,
 });
 
 export const RegisteredServerModel = model('registered_servers', RegisteredServerSchema);

--- a/src/models/UserModel.ts
+++ b/src/models/UserModel.ts
@@ -1,0 +1,9 @@
+import { Schema, model } from 'mongoose';
+import { WebsiteUser } from '@uoa-discords/shared-utils';
+
+export const UserSchema = new Schema<WebsiteUser>({
+    _id: String,
+    guildsLiked: [String],
+});
+
+export const UserModel = model('users', UserSchema);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,4 @@
-import { GETRoutes, POSTApplicationRoutes, POSTAuthRoutes } from '@uoa-discords/shared-utils';
+import { GETRoutes, POSTApplicationRoutes, POSTAuthRoutes, POSTUserRoutes } from '@uoa-discords/shared-utils';
 import { Router } from 'express';
 import {
     acceptApplication,
@@ -10,6 +10,7 @@ import {
 } from './handlers/applications';
 import { getToken, refreshToken, revokeToken } from './handlers/auth';
 import getServers from './handlers/servers/getServers';
+import addLike from './handlers/users/addLike';
 import getLikes from './handlers/users/getLikes';
 
 const router = Router();
@@ -22,7 +23,9 @@ router.post(POSTApplicationRoutes.Modify, modifyApplicationTags);
 
 router.get(GETRoutes.GetApplications, getApplications);
 router.get(GETRoutes.GetServers, getServers);
+
 router.get(GETRoutes.GetUserLikes, getLikes);
+router.post(POSTUserRoutes.AddLike, addLike);
 
 router.post(POSTAuthRoutes.GetToken, getToken);
 router.post(POSTAuthRoutes.RefreshToken, refreshToken);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -10,6 +10,7 @@ import {
 } from './handlers/applications';
 import { getToken, refreshToken, revokeToken } from './handlers/auth';
 import getServers from './handlers/servers/getServers';
+import getLikes from './handlers/users/getLikes';
 
 const router = Router();
 
@@ -21,6 +22,7 @@ router.post(POSTApplicationRoutes.Modify, modifyApplicationTags);
 
 router.get(GETRoutes.GetApplications, getApplications);
 router.get(GETRoutes.GetServers, getServers);
+router.get(GETRoutes.GetUserLikes, getLikes);
 
 router.post(POSTAuthRoutes.GetToken, getToken);
 router.post(POSTAuthRoutes.RefreshToken, refreshToken);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -12,6 +12,7 @@ import { getToken, refreshToken, revokeToken } from './handlers/auth';
 import getServers from './handlers/servers/getServers';
 import addLike from './handlers/users/addLike';
 import getLikes from './handlers/users/getLikes';
+import removeLike from './handlers/users/removeLike';
 
 const router = Router();
 
@@ -26,6 +27,7 @@ router.get(GETRoutes.GetServers, getServers);
 
 router.get(GETRoutes.GetUserLikes, getLikes);
 router.post(POSTUserRoutes.AddLike, addLike);
+router.post(POSTUserRoutes.RemoveLike, removeLike);
 
 router.post(POSTAuthRoutes.GetToken, getToken);
 router.post(POSTAuthRoutes.RefreshToken, refreshToken);

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,10 +855,10 @@
     "@typescript-eslint/types" "5.18.0"
     eslint-visitor-keys "^3.0.0"
 
-"@uoa-discords/shared-utils@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@uoa-discords/shared-utils/-/shared-utils-2.1.7.tgz#126009b990f222585e400cd89925ab811cfa4846"
-  integrity sha512-yPcya3XLAcJGCgzB7PFznJf/gCEr+VnL37mu4NdiTfKACvtTngRcC/WiX028chKjqnVO3Mo6EYrIW0+TqJjzxA==
+"@uoa-discords/shared-utils@^2.2.7":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@uoa-discords/shared-utils/-/shared-utils-2.2.7.tgz#9e34e0c73072379c40c01ab4cf018a04b58179fd"
+  integrity sha512-DuasrEsjIVFhXw2h+YzxzpZEhBpiodGao/U0aT4lyeK+EuGrJx6M0NORgC2BEHgiE0VkDxuKEc2F7N24eEFr+Q==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
Add a like or remove your like from a server.
The only requirements are that:
- The guild is fully registered (not an application).
- (If liking) The user has not already liked.

We do validation for the user being in the guild on the client-side (see [this PR](https://github.com/UoA-Discords/uoa-discords-website/pull/30)), but not on the server-side since it's not important enough to warrant a `/guilds/@me` API call.

We store likes in 2 ways:
1. An array of guild ID's in our new `WebsiteUser` database document.
2. A numerical value in each guilds `RegisteredServer` database document.

99% of the time these are accurate and in-sync, but that 1% means it's possible to make them desync, albeit rarely (and requiring intent to do so). My solution to this is to not care lol.